### PR TITLE
Readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ jobs:
         url: https://gitlab.com
         token: ${{ secrets.TOKEN }}
         project_id: 37728736
-        variables:
-          VAR1: "value1"
+        variables: |
+          VAR1="value1"
 ```
 
 In this case, you will need to upload the GitLab CI pipeline trigger token to the GitHub repository or organization secrets.
+The default value of `url` is `https://gitlab.com` and the `variables` parameter is optional.
+There is an additional `ref_name` option which has a default value of `main`.

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
 inputs:
   url:
     description: 'GitLab server url (at the level under which the API start)'
-    required: true
+    required: false
     default: 'https://gitlab.com'
   project_id:
     description: 'GitLab project ID'


### PR DESCRIPTION
The example for specifying variable names didn't works so I copied from the self test. Also made `url` parameter optional since it has a reasonable default.