### PR TITLE
Fix web_url output; add json output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,6 @@ jobs:
     - uses: peter-evans/commit-comment@v2
       with:
         body: |
-          [GitLab pipeline](${{ steps.trigger.outputs.web_url }})
+          [GitLab pipeline][1] has been submitted for this commit.
+          
+          [1]: ${{ steps.trigger.outputs.web_url }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,11 @@ jobs:
     name: Test against https://gitlab.com/eic/test-trigger-gitlab-ci
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout
+      uses: actions/checkout@v3
     - name: Trigger pipeline on test-trigger-gitlab-ci
       id: trigger
-      uses: eic/trigger-gitlab-ci@main
+      uses: ./
       with:
         url: "https://gitlab.com"
         token: ${{ secrets.TOKEN }}
@@ -17,7 +19,7 @@ jobs:
           VAR2=value2
     - name: Print json and web_url for further use
       run: |
-        test -z "${{ steps.trigger.outputs.json }}"
+        test -n "${{ steps.trigger.outputs.json }}"
         echo "json=${{ steps.trigger.outputs.json }}"
-        test -z "${{ steps.trigger.outputs.web_url }}"
+        test -n "${{ steps.trigger.outputs.web_url }}"
         echo "web_url=${{ steps.trigger.outputs.web_url }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
           VAR2=value2
     - name: Print json and web_url for further use
       run: |
-        test -n "${{ steps.trigger.outputs.json }}"
-        echo "json=${{ steps.trigger.outputs.json }}"
         test -n "${{ steps.trigger.outputs.web_url }}"
         echo "web_url=${{ steps.trigger.outputs.web_url }}"
+        echo "json.web_url=${{ fromJson(steps.trigger.outputs.json).web_url }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,3 +22,7 @@ jobs:
         test -n ${{ steps.trigger.outputs.web_url }}
         echo web_url=${{ steps.trigger.outputs.web_url }}
         echo json.web_url=${{ fromJson(steps.trigger.outputs.json).web_url }}
+    - uses: peter-evans/commit-comment@v2
+      with:
+        body: |
+          [GitLab pipeline](${{ steps.trigger.outputs.web_url }})

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ jobs:
         variables: |
           VAR1=value1
           VAR2=value2
-    - name: Print web_url for further use
+    - name: Print json and web_url for further use
       run: |
-        echo ${{ steps.trigger.outputs.web_url }}
+        test -z "${{ steps.trigger.outputs.json }}"
+        echo "json=${{ steps.trigger.outputs.json }}"
+        test -z "${{ steps.trigger.outputs.web_url }}"
+        echo "web_url=${{ steps.trigger.outputs.web_url }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: test
-on: [push]
+on: [push, pull_request]
 jobs:
   test-against-gitlab:
     name: Test against https://gitlab.com/eic/test-trigger-gitlab-ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,5 @@ jobs:
     - uses: peter-evans/commit-comment@v2
       with:
         body: |
-          [GitLab pipeline][1] has been submitted for this commit.
-          
-          [1]: ${{ steps.trigger.outputs.web_url }}
+          GitLab pipeline has been submitted for this commit:
+          ${{ steps.trigger.outputs.web_url }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,6 @@ jobs:
           VAR2=value2
     - name: Print json and web_url for further use
       run: |
-        test -n "${{ steps.trigger.outputs.web_url }}"
-        echo "web_url=${{ steps.trigger.outputs.web_url }}"
-        echo "json.web_url=${{ fromJson(steps.trigger.outputs.json).web_url }}"
+        test -n ${{ steps.trigger.outputs.web_url }}
+        echo web_url=${{ steps.trigger.outputs.web_url }}
+        echo json.web_url=${{ fromJson(steps.trigger.outputs.json).web_url }}

--- a/README.md
+++ b/README.md
@@ -71,5 +71,5 @@ jobs:
     - uses: peter-evans/commit-comment@v2
       with:
         body: |
-          [GitLab pipeline](${{ steps.trigger.outputs.web_url }})
+          GitLab pipeline: ${{ steps.trigger.outputs.web_url }}
 ```

--- a/README.md
+++ b/README.md
@@ -9,24 +9,66 @@ This GitHub Action triggers a GitLab CI pipeline through webhooks.
 
 You can use this GitHub Action in a workflow in your own repository with `uses: eic/trigger-gitlab-ci@v1`.
 
-A minimal job example for GitHub-hosted runners of type `ubuntu-latest`:
+A minimal job example looks as follows:
 ```yaml
 jobs:
-  run-eic-shell:
+  trigger-gitlab-ci:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: eic/trigger-gitlab-ci@v1
       with:
-        url: https://gitlab.com
-        token: ${{ secrets.TOKEN }}
         project_id: 37728736
+        token: ${{ secrets.TOKEN }}
+```
+You will need to upload the GitLab CI pipeline trigger token to the GitHub repository or organization secrets. This token can be created in the GitLab repository settings under CI/CD > Pipeline Triggers. 
+
+### Inputs
+This action requires the following inputs:
+- `project_id`: GitLab project ID
+- `token`: GitLab pipeline trigger token (GitLab Settings > CI/CD > Pipeline Triggers)
+
+This action also accepts several optional inputs:
+- `url`: GitLab server url (at the level under which the API starts), default: `https://gitlab.com`
+- `ref_name`: GitLab project ref_name (branch or tag name), default: `main`
+- `variables`: Additional variables in `VAR1=value VAR2=value` format to pass to the pipeline, default: ``
+
+A more advanced example could look as follows, passing variables for call backs:
+```yaml
+jobs:
+  trigger-gitlab-ci:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: eic/trigger-gitlab-ci@v1
+      with:
+        url: https://gitlab.cern.ch
+        project_id: 6751
+        token: ${{ secrets.TOKEN }}
+        ref_name: master
         variables: |
-          VAR1="value1"
+          GITHUB_REPOSITORYURL: ${{ github.repositoryUrl }}
+          GITHUB_SHA: ${{ github.sha }}
 ```
 
-In this case, you will need to upload the GitLab CI pipeline trigger token to the GitHub repository or organization secrets. This token can be created in the GitLab repository settings under CI/CD > Pipeline Triggers. 
+### Outputs
+This actions provides the following outputs:
+- `json`: GitLab webhook response (JSON)
+- `web_url`: GitLab pipeline URL
 
-The default value of `url` is `https://gitlab.com` and the `variables` parameter is optional.
-
-There is an additional `ref_name` option which has a default value of `main`.
+These outputs can be used as follows to print the GitLab pipeline URL to :
+```yaml
+jobs:
+  trigger-gitlab-ci:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: eic/trigger-gitlab-ci@v1
+      with:
+        project_id: 37728736
+        token: ${{ secrets.TOKEN }}
+    - uses: peter-evans/commit-comment@v2
+      with:
+        body: |
+          [GitLab pipeline](${{ steps.trigger.outputs.web_url }})
+```

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: eic/trigger-gitlab-ci@v1
+      id: trigger
       with:
         project_id: 37728736
         token: ${{ secrets.TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -46,14 +46,6 @@ runs:
             echo "Unable to parse variable $variable"
           fi
         done
-        # Print webhook call
-        echo curl -X POST \
-             --fail \
-             -o response.json \
-             -F "token=${TOKEN}" \
-             -F "ref=${REF_NAME}" \
-             ${variable_args} \
-             ${URL}/api/v4/projects/${PROJECT_ID}/trigger/pipeline
         # Call webhook
         curl -X POST \
              --fail \
@@ -62,8 +54,9 @@ runs:
              -F "ref=${REF_NAME}" \
              ${variable_args} \
              ${URL}/api/v4/projects/${PROJECT_ID}/trigger/pipeline
-        echo "web_url: $(cat response.json | jq -c '.web_url')"
-        echo "::set-output name=json::$(cat response.json)
+        # Print and parse json
+        jq . response.json
+        echo "::set-output name=json::$(cat response.json)"
         echo "::set-output name=web_url::$(cat response.json | jq -c '.web_url')"
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,14 @@ runs:
             echo "Unable to parse variable $variable"
           fi
         done
+        # Print webhook call
+        echo curl -X POST \
+             --fail \
+             -o response.json \
+             -F "token=${TOKEN}" \
+             -F "ref=${REF_NAME}" \
+             ${variable_args} \
+             ${URL}/api/v4/projects/${PROJECT_ID}/trigger/pipeline
         # Call webhook
         curl -X POST \
              --fail \

--- a/action.yml
+++ b/action.yml
@@ -25,10 +25,19 @@ inputs:
     required: false
     default: ''
 
+outputs:
+  json:
+    description: "GitLab webhook response (JSON)"
+    value: ${{ steps.call-webhook.outputs.json }}
+  web_url:
+    description: "GitLab pipeline URL"
+    value: ${{ steps.call-webhook.outputs.web_url }}
+
 runs:
   using: "composite"
   steps:
-    - run: |
+    - id: call-webhook
+      run: |
         # Parse VARIABLES into multiple arguments
         for variable in ${VARIABLES} ; do
           if [[ $variable =~ ^([a-zA-Z_][a-zA-Z0-9_]*)=(.*) ]] ; then
@@ -54,6 +63,7 @@ runs:
              ${variable_args} \
              ${URL}/api/v4/projects/${PROJECT_ID}/trigger/pipeline
         echo "web_url: $(cat response.json | jq -c '.web_url')"
+        echo "::set-output name=json::$(cat response.json)
         echo "::set-output name=web_url::$(cat response.json | jq -c '.web_url')"
       shell: bash
       env:


### PR DESCRIPTION
The webhook returns a json object with the web_url of the created pipeline. This fixes how this link is passed to the calling workflow (and provides access to the full json object).

Other small changes:
- webhook call is not printed (not scalable and not useful beyond debugging),
- use checkout to get current repository for testing, not a released version upstream.