### PR TITLE
fix: replace set-output with $GITHUB_OUTPUT

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,8 +66,8 @@ runs:
              ${URL}/api/v4/projects/${PROJECT_ID}/trigger/pipeline
         # Print and parse json
         jq . response.json
-        echo "::set-output name=json::$(cat response.json)"
-        echo "::set-output name=web_url::$(cat response.json | jq -c '.web_url')"
+        echo "json=$(cat response.json)" >> $GITHUB_OUTPUT
+        echo "web_url=$(cat response.json | jq -c '.web_url')" >> $GITHUB_OUTPUT
       shell: bash
       env:
         URL: ${{ inputs.url }}


### PR DESCRIPTION
### Briefly, what does this PR introduce?
"Starting today runner version 2.298.2 will begin to warn you if you use the save-state or set-output commands via stdout." [GitHub blog, 2022-10-11](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

This modifies the action to use the new way of providing outputs.

### What kind of change does this PR introduce?
- [X] Bug fix (issue: warnings on use due to new github actions policy)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.