### PR TITLE
fix: unquoted web_url, add robustness against multiline json

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,8 +68,12 @@ runs:
              || ( RETCODE="$?"; jq . response.json; exit "$RETCODE" )
         # Print and parse json
         jq . response.json
-        echo "json=$(cat response.json)" >> $GITHUB_OUTPUT
-        echo "web_url=$(cat response.json | jq -c '.web_url')" >> $GITHUB_OUTPUT
+        echo "json<<END" >> $GITHUB_OUTPUT
+        cat response.json >> $GITHUB_OUTPUT
+        echo "END" >> $GITHUB_OUTPUT
+        echo "web_url<<END" >> $GITHUB_OUTPUT
+        cat response.json | jq --raw-output '.web_url' >> $GITHUB_OUTPUT
+        echo "END" >> $GITHUB_OUTPUT
       shell: bash
       env:
         URL: ${{ inputs.url }}


### PR DESCRIPTION
Noticed that web_url is returned with extra `"` quotes. In principle, `fromJson(steps.foo.outputs.json).web_url` works, so we could get rid of web_url. In any case the quotes are not wanted, so this removes them.